### PR TITLE
Add AbstractLorentzVector

### DIFF
--- a/src/LorentzVectors.jl
+++ b/src/LorentzVectors.jl
@@ -12,6 +12,11 @@ export dot, ⋅, cross, ×, norm, normalize
 export boost, rotate
 export convert
 
+
+# abstract base type for Lorentz vectors
+abstract type AbstractLorentzVector end
+
+
 """
     LorentzVector(t, x, y, z)
 
@@ -20,7 +25,7 @@ Lorentz 4-vector, as used in Special Relativity.
 The metric convention is g = diag(+1,-1,-1,-1). No distinction is made between
 co- and contravariant vectors.
 """
-struct LorentzVector{T <: AbstractFloat}
+struct LorentzVector{T <: AbstractFloat} <: AbstractLorentzVector
     t :: T
     x :: T
     y :: T


### PR DESCRIPTION
### Pull Request Description

This PR introduces `AbstractLorentzVector` as the new supertype for your existing `LorentzVector`. While this may appear to be a minor change from your perspective, it significantly enhances our ability to standardize Lorentz vector implementations across the JuliaHEP ecosystem.

## Context

We are currently developing an [interface package](https://github.com/JuliaHEP/LorentzVectorBase.jl) designed to define a common framework for objects that behave like Lorentz vectors. This interface will facilitate:

1. **Uniform Accessor Naming:** By establishing common names for accessors, we can streamline the development process for implementations of Lorentz vector types.
2. **Interoperability with Consumer Libraries:** Libraries that utilize Lorentz-vector-like objects, such as `JetReconstruction.jl`, will benefit from consistent access patterns.

Since your package is already registered in the Julia package ecosystem, we would like to formally support your `LorentzVector` type. 

### What This Means for You

- **Minimal Impact:** Aside from this PR, no additional action is required on your part to support this change. Your existing usage of the package remains unchanged.
- **Future Compatibility:** We will implement the interface for your type within an extension of our package, ensuring that your `LorentzVector` can seamlessly integrate with consumer libraries in the future.

Thank you for considering this enhancement, and we look forward to improving interoperability within the JuliaHEP community!